### PR TITLE
Add Docker on Alpine:3.3 and readme update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Dockerfile for appsensor-reverse-proxy
+
+FROM alpine:3.3
+
+MAINTAINER John Melton <jtmelton@gmail.com>
+
+# default values override with -e
+ENV APPSENSOR_REST_ENGINE_URL=http://localhost:8085
+ENV APPSENSOR_CLIENT_APPLICATION_ID_HEADER_NAME=X-Appsensor-Client-Application-Name
+ENV APPSENSOR_CLIENT_APPLICATION_ID_HEADER_VALUE=reverse-proxy
+ENV APPSENSOR_CLIENT_APPLICATION_IP_ADDRESS=127.0.0.1
+
+# using ENV to allow dynamic loading of configuration files
+ENV resource-verbs-mapping-file=testdata/sample-resource-verbs-mapping.yml
+ENV resources-file=testdata/sample-resources.yml
+
+# work around for permission error when ADD creates directories that binary is in
+RUN mkdir /go && mkdir /go/bin
+
+# add specially compiled binary directly
+ADD appsensor-reverse-proxy /go/bin/proxy
+
+# add config files
+ADD $resource-verbs-mapping-file /tmp/resource-verbs-mapping.xml
+ADD $resources-file /tmp/resources.yml
+
+# cli args can be sent through as expected
+ENTRYPOINT ["/go/bin/proxy", "-resource-verbs-mapping-file=/tmp/resource-verbs-mapping.xml", "-resources-file=/tmp/resources.yml"]
+
+# if no cli args, default of -help is sent
+CMD ["-help"]
+# this is the default port to run appsensor-reverse-proxy on
+EXPOSE 8080
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # appsensor-reverse-proxy
 Reverse proxy to front-end appsensor (https://github.com/jtmelton/appsensor) and implement various detection points (found at https://www.owasp.org/index.php/AppSensor_DetectionPoints)
 
+### Compiling for Docker
+```
+CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o $GOPATH/appsensor-reverse-proxy
+```
+
 ## Usage
 This application gets built as a standalone binary (named appsensor-reverse-proxy). 
 
@@ -9,6 +14,18 @@ When running the reverse proxy, there are a number of parameters you can use to 
 Here's an example execution with several of the features enabled: 
 
 `appsensor-reverse-proxy -logtostderr=true -enable-blocking=true -enable-tls=true -enable-trend-tracking -blocking-blocks-refresh-url=http://localhost:8090/api/v1.0/blocks -enable-invalid-verb-checking=true -enable-unexpected-verb-checking=true -resource-verbs-mapping-file=testdata/sample-resource-verbs-mapping.yml -enable-unexpected-resource-checking=true -resources-file=testdata/sample-resources.yml`
+
+Below is an example of running in docker, you can load in your own configuarion files with `-e resource-verbs-mapping-file=/your/verbmappings.yml` this example defaults to the samples in the testdata folder. 
+
+To run in a container you'll need to build the proxy with this command
+```
+CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o $GOPATH/appsensor-reverse-proxy
+```
+
+Once it is built run the image like this
+```
+docker run -d -p 80:8080 appsensor/reverse-proxy -logtostderr=true -enable-blocking=true -enable-tls=false -enable-trend-tracking -blocking-blocks-refresh-url=http://localhost:8090/api/v1.0/blocks -enable-invalid-verb-checking=true -enable-unexpected-verb-checking=true -enable-unexpected-resource-checking=true
+```
 
 Below is an explanation of each of the flags you can send. 
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,35 @@
 # appsensor-reverse-proxy
 Reverse proxy to front-end appsensor (https://github.com/jtmelton/appsensor) and implement various detection points (found at https://www.owasp.org/index.php/AppSensor_DetectionPoints)
 
-### Compiling for Docker
-```
-CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o $GOPATH/appsensor-reverse-proxy
-```
-
-## Usage
+## Examples and Usage
 This application gets built as a standalone binary (named appsensor-reverse-proxy). 
 
 When running the reverse proxy, there are a number of parameters you can use to enable different features. 
 
-Here's an example execution with several of the features enabled: 
+*Here's an example execution with several of the features enabled:* 
 
 `appsensor-reverse-proxy -logtostderr=true -enable-blocking=true -enable-tls=true -enable-trend-tracking -blocking-blocks-refresh-url=http://localhost:8090/api/v1.0/blocks -enable-invalid-verb-checking=true -enable-unexpected-verb-checking=true -resource-verbs-mapping-file=testdata/sample-resource-verbs-mapping.yml -enable-unexpected-resource-checking=true -resources-file=testdata/sample-resources.yml`
 
-Below is an example of running in docker, you can load in your own configuarion files with `-e resource-verbs-mapping-file=/your/verbmappings.yml` this example defaults to the samples in the testdata folder. 
+*Below is an example of running in docker*
+
+`docker run -d -p 80:8080 appsensor/reverse-proxy -logtostderr=true -enable-blocking=true -enable-tls=false -enable-trend-tracking -blocking-blocks-refresh-url=http://localhost:8090/api/v1.0/blocks -enable-invalid-verb-checking=true -enable-unexpected-verb-checking=true -enable-unexpected-resource-checking=true`
+
+You can load in your own configuarion files with -e in the docker command. The example defaults to the samples in the testdata folder.
+```
+-e resource-verbs-mapping-file=/your/verbmappings.yml -e resources-file=/your/resourcemappings.yml
+```      
 
 To run in a container you'll need to build the proxy with this command
 ```
 CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o $GOPATH/appsensor-reverse-proxy
 ```
 
-Once it is built run the image like this
+Then build the container
 ```
-docker run -d -p 80:8080 appsensor/reverse-proxy -logtostderr=true -enable-blocking=true -enable-tls=false -enable-trend-tracking -blocking-blocks-refresh-url=http://localhost:8090/api/v1.0/blocks -enable-invalid-verb-checking=true -enable-unexpected-verb-checking=true -enable-unexpected-resource-checking=true
+docker build -t appsensor/reverse-proxy .
 ```
 
-Below is an explanation of each of the flags you can send. 
+*Below is an explanation the flags you can send*
 
 1. `--help`
    


### PR DESCRIPTION
I need to change some things to get TLS working and configurable, but this version works for dev purposes, at least as far as I can tell. 

I need to get something like webgoat setup behind it and check the deeper functionality.

After all that. CI -> Docker Hub and we can publish this image. Its is pretty darn small, less then 20mb when combined with its base image.

```
REPOSITORY                                               TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
appsensor/reverse-proxy                                  latest              5d9b851fc49f        57 minutes ago      14.65 MB
appsensor/appsensor-block-store                          latest              18a38e354990        3 hours ago         156.1 MB
appsensor/appsensor-ws-rest-server-boot                  latest              37d9c81fc9e1        23 hours ago        180 MB
appsensor/appsensor-ws-rest-server-with-websocket-boot   latest              df67917146d2        23 hours ago        252 MB
anapsix/alpine-java                                      latest              b8f7ad9dbe76        5 days ago          122.6 MB
alpine                                                   3.3                 9a686d8dd34c        8 days ago          4.798 MB

```
